### PR TITLE
Update sample to net8.0 rc 1

### DIFF
--- a/IdentityEndpointsSample/IdentityEndpointsSample.csproj
+++ b/IdentityEndpointsSample/IdentityEndpointsSample.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0-preview.7.23375.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-preview.7.23375.4" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-preview.7.23375.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0-rc.1.23421.29" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.1.23419.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-rc.1.23421.29" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 

--- a/IdentityEndpointsSample/app.http
+++ b/IdentityEndpointsSample/app.http
@@ -9,7 +9,6 @@ POST {{url}}/register
 Content-Type: application/json
 
 {
-  "username": "{{user}}",
   "password": "{{password}}",
   "email": "{{email}}"
 }
@@ -20,7 +19,7 @@ POST {{url}}/login
 Content-Type: application/json
 
 {
-  "username": "{{user}}",
+  "email": "{{email}}",
   "password": "{{password}}"
 }
 


### PR DESCRIPTION
The latest version of Identity remove the username field causing the current sample to fail for login etc.

This change:
- Updates to the latest prerelease NuGet dependencies
- Updates the sample http calls to use email instead of username